### PR TITLE
docs: remove CodeFund sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-<p align="center">
-<a href="https://codefund.io/properties/506/visit-sponsor">
-<img src="https://codefund.io/properties/506/sponsor" />
-</a>
-</p>
-
 # JavaScript ASTs Workshop
 
 _Improved productivity 💯 with the practical 🤓 use of the power 💪 of Abstract
@@ -224,4 +218,3 @@ MIT
 [contributing]: https://github.com/kentcdodds/asts-workshop/blob/master/CONTRIBUTING.md
 [nps]: https://npmjs.com/package/nps
 [tester]: https://github.com/babel-utils/babel-plugin-tester
-


### PR DESCRIPTION
**What**:

Remove CodeFund sponsor ad from the README

**Why**:

CodeFund is not allowed to place ads on README's anymore according to GitHub.
Please reach out to our team if you have any questions :slightly_smiling_face: 

**How**:

Remove code from the top of the README

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
